### PR TITLE
Fix python runtime in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.py": {
-      "runtime": "vercel-python@3.9"
+      "runtime": "python3.11"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- use `python3.11` runtime for serverless functions

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a65fac7e88324a0080a23251f9c6e