### PR TITLE
Trim env var and add test

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,6 @@
 import * as mockApi from './mockApi';
 
-const BASE_URL = import.meta.env.VITE_BACKEND_URL || '';
+const BASE_URL = (import.meta.env.VITE_BACKEND_URL || '').trim();
 const USE_MOCK = !BASE_URL || BASE_URL === 'mock';
 
 async function apiGet(path) {

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -39,3 +39,14 @@ test('fetchAnalysis adds query string when params provided', async () => {
     `${baseUrl}/analysis?start=2023-01-01&end=2023-02-01`
   );
 });
+
+test('whitespace in VITE_BACKEND_URL is trimmed for mock mode', async () => {
+  import.meta.env.VITE_BACKEND_URL = 'mock \n';
+  vi.resetModules();
+  const { fetchSteps } = await import('../../api');
+  global.fetch = vi.fn();
+  const result = await fetchSteps();
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(Array.isArray(result)).toBe(true);
+  import.meta.env.VITE_BACKEND_URL = 'test';
+});


### PR DESCRIPTION
## Summary
- trim whitespace around `VITE_BACKEND_URL` so `mock` mode works even if the env var has stray spaces
- add regression test demonstrating trimming logic

## Testing
- `npm install --silent`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a6be61cd88324a06b13c519c366ca