### PR TITLE
Add Activity Flow Sankey Chart

### DIFF
--- a/frontend/src/components/ActivityFlowSankeyChart.jsx
+++ b/frontend/src/components/ActivityFlowSankeyChart.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import Skeleton from "./ui/Skeleton";
+import { Sankey, Tooltip, ResponsiveContainer } from "recharts";
+import { fetchActivities } from "../api";
+
+export function bucketTimeOfDay(dateStr) {
+  const h = new Date(dateStr).getHours();
+  if (h < 6) return "Night";
+  if (h < 12) return "Morning";
+  if (h < 18) return "Afternoon";
+  return "Evening";
+}
+
+export function bucketDayType(dateStr) {
+  const d = new Date(dateStr).getDay();
+  return d === 0 || d === 6 ? "Weekend" : "Weekday";
+}
+
+export function computeActivityFlows(activities = []) {
+  const acts = [...activities].sort(
+    (a, b) => new Date(a.startTimeLocal) - new Date(b.startTimeLocal)
+  );
+  const flows = {};
+  const nodes = new Set();
+  for (let i = 0; i < acts.length - 1; i++) {
+    const cur = acts[i];
+    const next = acts[i + 1];
+    const fromTime = bucketTimeOfDay(cur.startTimeLocal);
+    const toTime = bucketTimeOfDay(next.startTimeLocal);
+    const timeKey = `${fromTime}|${toTime}`;
+    flows[timeKey] = (flows[timeKey] || 0) + 1;
+    nodes.add(fromTime);
+    nodes.add(toTime);
+
+    const fromDay = bucketDayType(cur.startTimeLocal);
+    const toDay = bucketDayType(next.startTimeLocal);
+    const dayKey = `${fromDay}|${toDay}`;
+    flows[dayKey] = (flows[dayKey] || 0) + 1;
+    nodes.add(fromDay);
+    nodes.add(toDay);
+  }
+  const nodeArr = Array.from(nodes).map((name) => ({ name }));
+  const idx = {};
+  nodeArr.forEach((n, i) => {
+    idx[n.name] = i;
+  });
+  const links = Object.entries(flows).map(([key, value]) => {
+    const [s, t] = key.split("|");
+    return { source: idx[s], target: idx[t], value };
+  });
+  return { nodes: nodeArr, links };
+}
+
+export default function ActivityFlowSankeyChart() {
+  const [data, setData] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchActivities({ limit: 1000 })
+      .then((acts) => setData(computeActivityFlows(acts)))
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <ChartCard title="Activity Flow">
+      <div className="h-64">
+        {loading && <Skeleton className="h-full w-full" />}
+        {error && (
+          <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
+            {error}
+          </div>
+        )}
+        {!loading && !error && data && (
+          <ResponsiveContainer width="100%" height="100%">
+            <Sankey data={data} nodePadding={20} linkCurvature={0.5}>
+              <Tooltip />
+            </Sankey>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </ChartCard>
+  );
+}
+

--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -7,6 +7,7 @@ import DayNightSplitChart from "./DayNightSplitChart";
 import CorrelationMap from "./CorrelationMap";
 
 import WhatIfScenarios from "./WhatIfScenarios";
+import ActivityFlowSankeyChart from "./ActivityFlowSankeyChart";
 
 
 
@@ -18,6 +19,7 @@ export default function AnalysisSection() {
 
       <WeatherImpactBubbleChart />
 
+      <ActivityFlowSankeyChart />
 
       <CorrelationMap />
 

--- a/frontend/src/components/__tests__/ActivityFlowSankeyChart.test.jsx
+++ b/frontend/src/components/__tests__/ActivityFlowSankeyChart.test.jsx
@@ -1,0 +1,55 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import ActivityFlowSankeyChart, { computeActivityFlows } from '../ActivityFlowSankeyChart';
+
+afterEach(() => vi.restoreAllMocks());
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() { this.cb([{ contentRect: { width: 100, height: 80 } }]); }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+test('computeActivityFlows aggregates transitions', () => {
+  const acts = [
+    { startTimeLocal: '2023-01-01T08:00:00' },
+    { startTimeLocal: '2023-01-02T18:00:00' },
+    { startTimeLocal: '2023-01-03T07:00:00' },
+  ];
+  const { nodes, links } = computeActivityFlows(acts);
+  const names = nodes.map(n => n.name);
+  const lookup = {};
+  links.forEach(l => {
+    const s = names[l.source];
+    const t = names[l.target];
+    lookup[`${s}-${t}`] = l.value;
+  });
+  expect(lookup['Morning-Evening']).toBe(1);
+  expect(lookup['Weekend-Weekday']).toBe(1);
+  expect(lookup['Evening-Morning']).toBe(1);
+  expect(lookup['Weekday-Weekday']).toBe(1);
+});
+
+test('fetches activity data on mount', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve([]),
+  });
+
+  render(<ActivityFlowSankeyChart />);
+  const base = import.meta.env.VITE_BACKEND_URL;
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${base}/activities?limit=1000`)
+  );
+});


### PR DESCRIPTION
## Summary
- visualize transitions between activities with a Sankey diagram
- include ActivityFlowSankeyChart in trends analysis
- test flow aggregation and data fetch

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7cf9be688324810c1dd7a9aa4743