### PR TITLE
Add WeeklyRingsDashboard component

### DIFF
--- a/frontend/src/components/WeeklyRingsDashboard.jsx
+++ b/frontend/src/components/WeeklyRingsDashboard.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { parseISO, startOfWeek, format } from "date-fns";
+import { fetchDailyTotals } from "../api";
+
+export function groupByWeek(totals) {
+  const weeks = {};
+  for (const { date, distance } of totals) {
+    const weekStart = format(
+      startOfWeek(parseISO(date), { weekStartsOn: 1 }),
+      "yyyy-MM-dd"
+    );
+    weeks[weekStart] = (weeks[weekStart] || 0) + distance;
+  }
+  return Object.entries(weeks)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([weekStart, dist]) => ({ weekStart, distanceKm: dist / 1000 }));
+}
+
+export default function WeeklyRingsDashboard({
+  goalKm = 40,
+  weeksToShow = 4,
+  size = 200,
+  strokeWidth = 10,
+}) {
+  const [weeks, setWeeks] = React.useState([]);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchDailyTotals()
+      .then((rows) => {
+        setWeeks(groupByWeek(rows).slice(-weeksToShow));
+      })
+      .catch(() => setError("Failed to load"));
+  }, [weeksToShow]);
+
+  if (error) {
+    return <div className="text-sm text-destructive">{error}</div>;
+  }
+
+  const gap = 4;
+  const cx = size / 2;
+  const cy = size / 2;
+  const baseRadius = size / 2 - strokeWidth / 2;
+  const rings = [...weeks].reverse().map((w, idx) => {
+    const r = baseRadius - idx * (strokeWidth + gap);
+    const pct = Math.max(0, Math.min(1, w.distanceKm / goalKm));
+    const circ = 2 * Math.PI * r;
+    return { ...w, r, pct, circ };
+  });
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      data-testid="weekly-rings"
+    >
+      <style>{`
+        @keyframes draw-ring {
+          to { stroke-dashoffset: 0; }
+        }
+      `}</style>
+      {rings.map((ring) => (
+        <circle
+          key={ring.weekStart}
+          cx={cx}
+          cy={cy}
+          r={ring.r}
+          fill="none"
+          stroke="hsl(var(--primary))"
+          strokeWidth={strokeWidth}
+          strokeDasharray={ring.circ}
+          strokeDashoffset={ring.circ * (1 - ring.pct)}
+          transform={`rotate(-90 ${cx} ${cy})`}
+          style={{ animation: "draw-ring 1s ease forwards" }}
+          data-week={ring.weekStart}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/components/__tests__/WeeklyRingsDashboard.test.jsx
+++ b/frontend/src/components/__tests__/WeeklyRingsDashboard.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import WeeklyRingsDashboard, { groupByWeek } from '../WeeklyRingsDashboard';
+import { vi } from 'vitest';
+
+afterEach(() => vi.restoreAllMocks());
+
+function makeTotals(days, dist) {
+  const totals = [];
+  const start = new Date('2023-01-01');
+  for (let i = 0; i < days; i++) {
+    const d = new Date(start.getTime() + i * 86400000);
+    totals.push({ date: d.toISOString().split('T')[0], distance: dist, duration: 0 });
+  }
+  return totals;
+}
+
+test('renders one circle per week', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(makeTotals(14, 5000)),
+  });
+
+  const { container } = render(<WeeklyRingsDashboard weeksToShow={3} goalKm={40} />);
+  await screen.findByTestId('weekly-rings');
+  const circles = container.querySelectorAll('circle');
+  const expected = groupByWeek(makeTotals(14, 5000)).length;
+  expect(circles.length).toBe(expected);
+});
+
+test('circles include animation style', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(makeTotals(7, 5000)),
+  });
+
+  const { container } = render(<WeeklyRingsDashboard weeksToShow={1} goalKm={40} />);
+  await screen.findByTestId('weekly-rings');
+  const circle = container.querySelector('circle');
+  expect(circle.getAttribute('stroke-dasharray')).toBeTruthy();
+  expect(circle.style.animation).toContain('draw-ring');
+});


### PR DESCRIPTION
## Summary
- add new `WeeklyRingsDashboard` component rendering animated concentric rings
- group mileage totals by week using `fetchDailyTotals`
- include tests for ring counts and animation attributes

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688a7f7f21348324bd920651999cf0b9