### PR TITLE
Fix Activity Flow by handling quoted backend URL

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 import * as mockApi from './mockApi';
 
-const BASE_URL = (import.meta.env.VITE_BACKEND_URL || '').trim();
+const RAW_URL = (import.meta.env.VITE_BACKEND_URL || '').trim();
+const BASE_URL = RAW_URL.replace(/^['"]|['"]$/g, '');
 const USE_MOCK = !BASE_URL || BASE_URL === 'mock';
 
 async function apiGet(path) {

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -50,3 +50,14 @@ test('whitespace in VITE_BACKEND_URL is trimmed for mock mode', async () => {
   expect(Array.isArray(result)).toBe(true);
   import.meta.env.VITE_BACKEND_URL = 'test';
 });
+
+test('quotes in VITE_BACKEND_URL are stripped for mock mode', async () => {
+  import.meta.env.VITE_BACKEND_URL = '"mock"';
+  vi.resetModules();
+  const { fetchSteps } = await import('../../api');
+  global.fetch = vi.fn();
+  const result = await fetchSteps();
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(Array.isArray(result)).toBe(true);
+  import.meta.env.VITE_BACKEND_URL = 'test';
+});


### PR DESCRIPTION
## Summary
- handle quotes around `VITE_BACKEND_URL`
- test that quoting is stripped for mock mode

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a7f5f24948324aeb0614caa0908d7