### PR TITLE
Add WeeklyRingsDashboard to dashboard

### DIFF
--- a/frontend/src/components/DashboardTabs.jsx
+++ b/frontend/src/components/DashboardTabs.jsx
@@ -6,6 +6,7 @@ import KPIGrid from "./KPIGrid";
 import FitnessScoreDial from "./FitnessScoreDial";
 import TemperatureChart from "./TemperatureChart";
 import WeatherChart from "./WeatherChart";
+import WeeklyRingsDashboard from "./WeeklyRingsDashboard";
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
 
 export default function DashboardTabs() {
@@ -25,6 +26,9 @@ export default function DashboardTabs() {
         </div>
         <KPIGrid />
         <FitnessScoreDial />
+        <div className="flex justify-center">
+          <WeeklyRingsDashboard />
+        </div>
       </TabsContent>
       <TabsContent value="trends" className="space-y-10">
         <React.Suspense fallback={<div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">Loading analysis...</div>}>


### PR DESCRIPTION
## Summary
- include the new WeeklyRingsDashboard component in DashboardTabs
- render WeeklyRingsDashboard on the overview tab

## Testing
- `cd frontend && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8130c5a08324b957f102ae3b30b2