### PR TITLE
Add animated flame streak icon

### DIFF
--- a/frontend/src/components/AnimatedFlame.jsx
+++ b/frontend/src/components/AnimatedFlame.jsx
@@ -1,0 +1,18 @@
+import { Flame } from "lucide-react";
+
+export default function AnimatedFlame({ streak = 0 }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative">
+        {/* Flame with subtle scale + color animation */}
+        <Flame
+          className="w-6 h-6 text-orange-400 animate-flame"
+          strokeWidth={2}
+        />
+        {/* Soft glow inside a blurred circle */}
+        <span className="absolute inset-0 rounded-full bg-orange-400 opacity-30 blur-md animate-glow"></span>
+      </div>
+      <span className="font-medium text-orange-400">{streak}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/StreakFlame.jsx
+++ b/frontend/src/components/StreakFlame.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flame } from 'lucide-react';
+import AnimatedFlame from './AnimatedFlame';
 import { fetchDailyTotals } from '../api';
 
 export function computeStreak(totals = []) {
@@ -25,23 +25,9 @@ export default function StreakFlame({ count }) {
       .catch(() => setDays(0));
   }, [count]);
 
-  const levels = [
-    'text-muted-foreground',
-    'text-orange-400',
-    'text-orange-500',
-    'text-red-600',
-  ];
-  let idx = 0;
-  if (days >= 14) idx = 3;
-  else if (days >= 7) idx = 2;
-  else if (days >= 3) idx = 1;
-
-  const activeClass = days ? 'streak-active' : '';
-
   return (
-    <div className="flex items-center" title={`${days} day streak`}>
-      <Flame className={`lucide-flame ${levels[idx]} ${activeClass}`} />
-      <span className={`ml-1 text-xs font-medium ${levels[idx]}`}>{days}</span>
+    <div title={`${days} day streak`}>
+      <AnimatedFlame streak={days} />
     </div>
   );
 }

--- a/frontend/src/components/__tests__/StreakFlame.test.jsx
+++ b/frontend/src/components/__tests__/StreakFlame.test.jsx
@@ -15,9 +15,10 @@ it('computeStreak counts consecutive days', () => {
   expect(computeStreak(totals)).toBe(2);
 });
 
-it('renders correct intensity class', () => {
+it('renders animated flame with glow', () => {
   const { container } = render(<StreakFlame count={8} />);
   const svg = container.querySelector('svg.lucide-flame');
-  expect(svg.classList.contains('text-orange-500')).toBe(true);
-  expect(svg.classList.contains('streak-active')).toBe(true);
+  const glow = container.querySelector('span.animate-glow');
+  expect(svg.classList.contains('animate-flame')).toBe(true);
+  expect(glow).not.toBeNull();
 });

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -96,16 +96,23 @@
 }
 
 @layer components {
-  .streak-active {
-    filter: drop-shadow(0 0 4px rgba(249, 115, 22, 0.8));
-    animation: flame-pulse 1.5s infinite;
+  .animate-flame {
+    animation: flamePulse 1.4s ease-in-out infinite;
   }
-  .streak-active:hover {
-    filter: drop-shadow(0 0 8px rgba(249, 115, 22, 1));
+
+  .animate-glow {
+    animation: softGlow 2s ease-in-out infinite;
   }
 }
 
-@keyframes flame-pulse {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(249, 115, 22, 0.8)); }
-  50% { filter: drop-shadow(0 0 8px rgba(249, 115, 22, 1)); }
+@keyframes flamePulse {
+  0% { transform: scale(1); color: #f97316; }
+  50% { transform: scale(1.08); color: #fdba74; }
+  100% { transform: scale(1); color: #f97316; }
+}
+
+@keyframes softGlow {
+  0% { opacity: 0.2; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(1.2); }
+  100% { opacity: 0.2; transform: scale(1); }
 }


### PR DESCRIPTION
## Summary
- add `AnimatedFlame` component for streak icon animation
- refactor `StreakFlame` to use new animated flame
- update global CSS for flame animations
- adjust StreakFlame tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a825b054c8324a35b3d4686eb38b5