### PR TITLE
Add fitness breakdown radial chart

### DIFF
--- a/frontend/src/components/FitnessBreakdownChart.jsx
+++ b/frontend/src/components/FitnessBreakdownChart.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import Skeleton from "./ui/Skeleton";
+import { fetchSteps, fetchSleep, fetchHeartrate } from "../api";
+
+export default function FitnessBreakdownChart({ size = 200, strokeWidth = 12 }) {
+  const [metrics, setMetrics] = React.useState([]);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    async function load() {
+      try {
+        const [steps, sleep, hr] = await Promise.all([
+          fetchSteps(),
+          fetchSleep(),
+          fetchHeartrate(),
+        ]);
+        const latestSteps = steps[steps.length - 1]?.value ?? 0;
+        const lastSleep = sleep[sleep.length - 1]?.value ?? 0;
+        const avgHr = Math.round(
+          hr.reduce((s, p) => s + p.value, 0) / (hr.length || 1)
+        );
+        setMetrics([
+          { label: "Steps", value: latestSteps, goal: 10000, color: "hsl(var(--primary))" },
+          { label: "Sleep", value: lastSleep, goal: 8, color: "hsl(var(--accent))" },
+          { label: "HR Avg", value: avgHr, goal: 100, color: "hsl(var(--muted-foreground))" },
+        ]);
+      } catch (err) {
+        setError("Failed to load");
+      }
+    }
+    load();
+  }, []);
+
+  const gap = 4;
+  const cx = size / 2;
+  const cy = size / 2;
+  const baseRadius = size / 2 - strokeWidth / 2;
+  const rings = metrics.map((m, idx) => {
+    const r = baseRadius - idx * (strokeWidth + gap);
+    const pct = Math.max(0, Math.min(1, m.value / m.goal));
+    const circ = 2 * Math.PI * r;
+    return { ...m, r, pct, circ };
+  });
+
+  return (
+    <ChartCard title="Fitness Breakdown">
+      <div className="flex justify-center items-center h-60">
+        {!metrics.length && !error && (
+          <Skeleton className="h-40 w-40 rounded-full" />
+        )}
+        {error && (
+          <div className="text-sm text-destructive">{error}</div>
+        )}
+        {metrics.length > 0 && (
+          <svg
+            width={size}
+            height={size}
+            viewBox={`0 0 ${size} ${size}`}
+            data-testid="fitness-rings"
+          >
+            <style>{`@keyframes fill-ring { to { stroke-dashoffset: 0; } }`}</style>
+            {rings.map((ring) => (
+              <circle
+                key={ring.label}
+                cx={cx}
+                cy={cy}
+                r={ring.r}
+                fill="none"
+                stroke={ring.color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={ring.circ}
+                strokeDashoffset={ring.circ * (1 - ring.pct)}
+                transform={`rotate(-90 ${cx} ${cy})`}
+                style={{ animation: "fill-ring 1s ease forwards" }}
+              />
+            ))}
+          </svg>
+        )}
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/__tests__/FitnessBreakdownChart.test.jsx
+++ b/frontend/src/components/__tests__/FitnessBreakdownChart.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import FitnessBreakdownChart from '../FitnessBreakdownChart';
+
+afterEach(() => vi.restoreAllMocks());
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() { this.cb([{ contentRect: { width: 120, height: 120 } }]); }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 120,
+    height: 120,
+    top: 0,
+    left: 0,
+    bottom: 120,
+    right: 120,
+  });
+});
+
+function mockMetric(val) {
+  return [{ timestamp: '2023-01-01T00:00:00', value: val }];
+}
+
+test('renders one circle per metric', async () => {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockMetric(5000)) })
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockMetric(6)) })
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockMetric(80)) });
+
+  const { container } = render(<FitnessBreakdownChart />);
+  await screen.findByTestId('fitness-rings');
+  const circles = container.querySelectorAll('circle');
+  expect(circles.length).toBe(3);
+});
+
+test('fetches metrics on mount', async () => {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
+
+  render(<FitnessBreakdownChart />);
+  const base = import.meta.env.VITE_BACKEND_URL;
+  await screen.findByTestId('fitness-rings');
+  expect(global.fetch).toHaveBeenCalledWith(`${base}/steps`);
+  expect(global.fetch).toHaveBeenCalledWith(`${base}/sleep`);
+  expect(global.fetch).toHaveBeenCalledWith(`${base}/heartrate`);
+});


### PR DESCRIPTION
## Summary
- add `FitnessBreakdownChart` stacked radial component
- test the chart rendering and API requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a81dcb0848324a36594040c14cae8