### PR TITLE
Update streak flame animation

### DIFF
--- a/frontend/src/components/AnimatedFlame.jsx
+++ b/frontend/src/components/AnimatedFlame.jsx
@@ -1,17 +1,18 @@
 import { Flame } from "lucide-react";
 
 export default function AnimatedFlame({ streak = 0 }) {
+  const fillOpacity = Math.min(0.2 + streak * 0.05, 0.8);
+  const fill = `rgba(249, 115, 22, ${fillOpacity})`;
+
   return (
     <div className="flex items-center gap-2">
-      <div className="relative">
-        {/* Flame with subtle scale + color animation */}
-        <Flame
-          className="w-6 h-6 text-orange-400 animate-flame"
-          strokeWidth={2}
-        />
-        {/* Soft glow inside a blurred circle */}
-        <span className="absolute inset-0 rounded-full bg-orange-400 opacity-30 blur-md animate-glow"></span>
-      </div>
+      {/* Simple flame icon with animated outline */}
+      <Flame
+        className="w-6 h-6 animate-flame"
+        strokeWidth={2}
+        color="#f97316"
+        fill={fill}
+      />
       <span className="font-medium text-orange-400">{streak}</span>
     </div>
   );

--- a/frontend/src/components/__tests__/StreakFlame.test.jsx
+++ b/frontend/src/components/__tests__/StreakFlame.test.jsx
@@ -15,10 +15,9 @@ it('computeStreak counts consecutive days', () => {
   expect(computeStreak(totals)).toBe(2);
 });
 
-it('renders animated flame with glow', () => {
+it('renders animated flame with dynamic fill', () => {
   const { container } = render(<StreakFlame count={8} />);
   const svg = container.querySelector('svg.lucide-flame');
-  const glow = container.querySelector('span.animate-glow');
   expect(svg.classList.contains('animate-flame')).toBe(true);
-  expect(glow).not.toBeNull();
+  expect(svg.getAttribute('fill')).toMatch(/rgba\(/);
 });

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -97,22 +97,12 @@
 
 @layer components {
   .animate-flame {
-    animation: flamePulse 1.4s ease-in-out infinite;
-  }
-
-  .animate-glow {
-    animation: softGlow 2s ease-in-out infinite;
+    animation: flameStroke 1.4s ease-in-out infinite;
   }
 }
 
-@keyframes flamePulse {
-  0% { transform: scale(1); color: #f97316; }
-  50% { transform: scale(1.08); color: #fdba74; }
-  100% { transform: scale(1); color: #f97316; }
-}
-
-@keyframes softGlow {
-  0% { opacity: 0.2; transform: scale(1); }
-  50% { opacity: 0.4; transform: scale(1.2); }
-  100% { opacity: 0.2; transform: scale(1); }
+@keyframes flameStroke {
+  0% { stroke: #f97316; }
+  50% { stroke: #fdba74; }
+  100% { stroke: #f97316; }
 }


### PR DESCRIPTION
## Summary
- simplify streak flame animation
- remove glow effect
- update CSS animation to stroke-only
- adjust unit test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a858218808324bc77e2d8e4030855