### PR TITLE
Implement Tooltip component across UI

### DIFF
--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { fetchDailyTotals } from "../api";
 import Skeleton from "./ui/Skeleton";
+import Tooltip from "./ui/tooltip";
 
 export default function CalendarHeatmap() {
   const [data, setData] = React.useState([]);
@@ -36,11 +37,12 @@ export default function CalendarHeatmap() {
         else if (intensity > 0.25) idx = 1;
         const title = `${d.date} - ${(d.distance / 1000).toFixed(1)} km, ${(d.duration / 60).toFixed(0)} min`;
         return (
-          <div
-            key={d.date}
-            className={`h-4 w-4 rounded transition-transform hover:scale-110 focus:scale-110 heatmap-scale-${idx}`}
-            title={title}
-          />
+          <Tooltip key={d.date} text={title}>
+            <div
+              className={`h-4 w-4 rounded transition-transform hover:scale-110 focus:scale-110 heatmap-scale-${idx}`}
+              title={title}
+            />
+          </Tooltip>
         );
       })}
     </div>

--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ChartCard from "./ChartCard";
 import Skeleton from "./ui/Skeleton";
+import TooltipWrapper from "./ui/tooltip";
 import {
   LineChart,
   Line,
@@ -51,13 +52,15 @@ export default function CumulativeChart() {
   const Dot = (props) => {
     const { cx, cy, payload } = props;
     return (
-      <circle
-        cx={cx}
-        cy={cy}
-        r={3}
-        fill="hsl(var(--primary))"
-        title={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}
-      />
+      <TooltipWrapper text={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={3}
+          fill="hsl(var(--primary))"
+          title={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}
+        />
+      </TooltipWrapper>
     );
   };
 

--- a/frontend/src/components/CumulativeTimeChart.jsx
+++ b/frontend/src/components/CumulativeTimeChart.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ChartCard from "./ChartCard";
 import Skeleton from "./ui/Skeleton";
+import TooltipWrapper from "./ui/tooltip";
 import {
   LineChart,
   Line,
@@ -51,13 +52,15 @@ export default function CumulativeTimeChart() {
   const Dot = (props) => {
     const { cx, cy, payload } = props;
     return (
-      <circle
-        cx={cx}
-        cy={cy}
-        r={3}
-        fill="hsl(var(--primary))"
-        title={`${payload.month}: ${payload.cumulative.toFixed(1)} h`}
-      />
+      <TooltipWrapper text={`${payload.month}: ${payload.cumulative.toFixed(1)} h`}>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={3}
+          fill="hsl(var(--primary))"
+          title={`${payload.month}: ${payload.cumulative.toFixed(1)} h`}
+        />
+      </TooltipWrapper>
     );
   };
 

--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -1,4 +1,5 @@
 import { states } from "@/data/states";
+import Tooltip from "./ui/tooltip";
 
 /**
  * Display grid of state abbreviations. Clicking a state
@@ -13,15 +14,19 @@ export default function StatesGrid({ onSelect, selected }) {
           : "bg-muted text-muted-foreground";
         const selectedClass = selected === s.abbr ? "ring-2 ring-primary" : "";
         return (
-          <div
+          <Tooltip
             key={s.abbr}
-            style={{ gridColumn: s.col, gridRow: s.row }}
-            onClick={() => onSelect?.(s.abbr)}
-            className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${visitedClass} ${selectedClass}`}
-            title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
+            text={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
           >
-            {s.abbr}
-          </div>
+            <div
+              style={{ gridColumn: s.col, gridRow: s.row }}
+              onClick={() => onSelect?.(s.abbr)}
+              className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${visitedClass} ${selectedClass}`}
+              title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
+            >
+              {s.abbr}
+            </div>
+          </Tooltip>
         );
       })}
     </div>

--- a/frontend/src/components/StreakFlame.jsx
+++ b/frontend/src/components/StreakFlame.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AnimatedFlame from './AnimatedFlame';
 import { fetchDailyTotals } from '../api';
+import Tooltip from './ui/tooltip';
 
 export function computeStreak(totals = []) {
   const dates = new Set(totals.map((t) => t.date));
@@ -25,9 +26,10 @@ export default function StreakFlame({ count }) {
       .catch(() => setDays(0));
   }, [count]);
 
-  return (
+  const flame = (
     <div title={`${days} day streak`}>
       <AnimatedFlame streak={days} />
     </div>
   );
+  return <Tooltip text={`${days} day streak`}>{flame}</Tooltip>;
 }

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
+import Tooltip from "./tooltip";
 
 export default function ProgressRing({
   value = 0,
@@ -13,7 +14,7 @@ export default function ProgressRing({
   const data = [{ name: "progress", value: percent }];
   const gradientId = React.useId();
 
-  return (
+  const ring = (
     <div
       className={"relative " + className}
       style={{ width: size, height: size }}
@@ -55,4 +56,6 @@ export default function ProgressRing({
       </div>
     </div>
   );
+
+  return title ? <Tooltip text={title}>{ring}</Tooltip> : ring;
 }


### PR DESCRIPTION
## Summary
- add `Tooltip` wrapper import to various components
- wrap elements with `Tooltip` while keeping `title` for accessibility
- update ProgressRing, StreakFlame, CalendarHeatmap, StatesGrid
- show data point details in CumulativeChart and CumulativeTimeChart with tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a86373f8c83249de541d7651041c4