### PR TITLE
Remove flame pulse animation

### DIFF
--- a/frontend/src/components/AnimatedFlame.jsx
+++ b/frontend/src/components/AnimatedFlame.jsx
@@ -6,9 +6,9 @@ export default function AnimatedFlame({ streak = 0 }) {
 
   return (
     <div className="flex items-center gap-2">
-      {/* Simple flame icon with animated outline */}
+      {/* Simple flame icon without pulsing animation */}
       <Flame
-        className="w-6 h-6 animate-flame"
+        className="w-6 h-6"
         strokeWidth={2}
         color="#f97316"
         fill={fill}

--- a/frontend/src/components/__tests__/StreakFlame.test.jsx
+++ b/frontend/src/components/__tests__/StreakFlame.test.jsx
@@ -15,9 +15,9 @@ it('computeStreak counts consecutive days', () => {
   expect(computeStreak(totals)).toBe(2);
 });
 
-it('renders animated flame with dynamic fill', () => {
+it('renders flame with dynamic fill', () => {
   const { container } = render(<StreakFlame count={8} />);
   const svg = container.querySelector('svg.lucide-flame');
-  expect(svg.classList.contains('animate-flame')).toBe(true);
+  expect(svg.classList.contains('animate-flame')).toBe(false);
   expect(svg.getAttribute('fill')).toMatch(/rgba\(/);
 });


### PR DESCRIPTION
## Summary
- stop applying the `animate-flame` class so the flame no longer pulses
- update StreakFlame test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a870ccd108324b5d54e8508c8d015