### PR TITLE
Add chart gallery page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,33 @@
 import React from "react";
 import DashboardPage from "@/components/DashboardPage";
+import AllChartsPage from "@/components/AllChartsPage";
 import ModeToggle from "@/components/ModeToggle";
 
 export default function App() {
+  const [page, setPage] = React.useState("dashboard");
+
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="p-4 flex justify-end">
+      <div className="p-4 flex justify-between">
+        {page === "dashboard" ? (
+          <button
+            className="text-sm underline"
+            onClick={() => setPage("charts")}
+          >
+            View All Charts
+          </button>
+        ) : (
+          <button
+            className="text-sm underline"
+            onClick={() => setPage("dashboard")}
+          >
+            Back to Dashboard
+          </button>
+        )}
         <ModeToggle />
       </div>
       <main className="mx-auto max-w-[1200px]">
-        <DashboardPage />
+        {page === "dashboard" ? <DashboardPage /> : <AllChartsPage />}
       </main>
     </div>
   );

--- a/frontend/src/components/AllChartsPage.jsx
+++ b/frontend/src/components/AllChartsPage.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import WeeklySummaryCard from "./WeeklySummaryCard";
+import StreakFlame from "./StreakFlame";
+import TemperatureChart from "./TemperatureChart";
+import WeatherChart from "./WeatherChart";
+import KPIGrid from "./KPIGrid";
+import FitnessScoreDial from "./FitnessScoreDial";
+import WeeklyRingsDashboard from "./WeeklyRingsDashboard";
+import AnalysisSection from "./AnalysisSection";
+
+export default function AllChartsPage() {
+  return (
+    <div className="p-6 space-y-6">
+      <WeeklySummaryCard>
+        <StreakFlame />
+      </WeeklySummaryCard>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TemperatureChart />
+        <WeatherChart />
+      </div>
+      <KPIGrid />
+      <FitnessScoreDial />
+      <div className="flex justify-center">
+        <WeeklyRingsDashboard />
+      </div>
+      <AnalysisSection />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AllChartsPage` that renders every chart component
- update `App` to toggle between dashboard and chart gallery

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a880a05d883248a13dd45c5d53cbe