### PR TITLE
Fix duplicate tooltips

### DIFF
--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -40,7 +40,8 @@ export default function CalendarHeatmap() {
           <Tooltip key={d.date} text={title}>
             <div
               className={`h-4 w-4 rounded transition-transform hover:scale-110 focus:scale-110 heatmap-scale-${idx}`}
-              title={title}
+              aria-label={title}
+              data-testid="heatmap-square"
             />
           </Tooltip>
         );

--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -58,7 +58,7 @@ export default function CumulativeChart() {
           cy={cy}
           r={3}
           fill="hsl(var(--primary))"
-          title={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}
+          aria-label={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}
         />
       </TooltipWrapper>
     );

--- a/frontend/src/components/CumulativeTimeChart.jsx
+++ b/frontend/src/components/CumulativeTimeChart.jsx
@@ -58,7 +58,7 @@ export default function CumulativeTimeChart() {
           cy={cy}
           r={3}
           fill="hsl(var(--primary))"
-          title={`${payload.month}: ${payload.cumulative.toFixed(1)} h`}
+          aria-label={`${payload.month}: ${payload.cumulative.toFixed(1)} h`}
         />
       </TooltipWrapper>
     );

--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -22,7 +22,7 @@ export default function StatesGrid({ onSelect, selected }) {
               style={{ gridColumn: s.col, gridRow: s.row }}
               onClick={() => onSelect?.(s.abbr)}
               className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${visitedClass} ${selectedClass}`}
-              title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
+              aria-label={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
             >
               {s.abbr}
             </div>

--- a/frontend/src/components/StreakFlame.jsx
+++ b/frontend/src/components/StreakFlame.jsx
@@ -27,7 +27,7 @@ export default function StreakFlame({ count }) {
   }, [count]);
 
   const flame = (
-    <div title={`${days} day streak`}>
+    <div aria-label={`${days} day streak`}>
       <AnimatedFlame streak={days} />
     </div>
   );

--- a/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
+++ b/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
@@ -15,7 +15,7 @@ it('renders squares with tooltip text', async () => {
   });
 
   render(<CalendarHeatmap />);
-  const square = await screen.findByTitle(/2023-01-01/);
-  expect(square.getAttribute('title')).toMatch('2023-01-01');
-  expect(await screen.findAllByTitle(/2023-01-0[12]/)).toHaveLength(2);
+  const squares = await screen.findAllByTestId('heatmap-square');
+  expect(squares).toHaveLength(2);
+  expect(squares[0]).toHaveAttribute('aria-label', expect.stringContaining('2023-01-01'));
 });

--- a/frontend/src/components/__tests__/CumulativeChart.test.jsx
+++ b/frontend/src/components/__tests__/CumulativeChart.test.jsx
@@ -37,7 +37,7 @@ it('renders cumulative mileage points', async () => {
   });
 
   render(<CumulativeChart />);
-  const dots = await screen.findAllByTitle(/2023-(01|02)/);
-  const titles = dots.map((d) => d.getAttribute('title'));
-  expect(titles).toEqual(['2023-01: 3.0 km', '2023-02: 6.0 km']);
+  const dots = await screen.findAllByLabelText(/2023-(01|02)/);
+  const labels = dots.map((d) => d.getAttribute('aria-label'));
+  expect(labels).toEqual(['2023-01: 3.0 km', '2023-02: 6.0 km']);
 });

--- a/frontend/src/components/__tests__/CumulativeTimeChart.test.jsx
+++ b/frontend/src/components/__tests__/CumulativeTimeChart.test.jsx
@@ -37,7 +37,7 @@ it('renders cumulative time points', async () => {
   });
 
   render(<CumulativeTimeChart />);
-  const dots = await screen.findAllByTitle(/2023-(01|02)/);
-  const titles = dots.map((d) => d.getAttribute('title'));
-  expect(titles).toEqual(['2023-01: 1.0 h', '2023-02: 2.0 h']);
+  const dots = await screen.findAllByLabelText(/2023-(01|02)/);
+  const labels = dots.map((d) => d.getAttribute('aria-label'));
+  expect(labels).toEqual(['2023-01: 1.0 h', '2023-02: 2.0 h']);
 });

--- a/frontend/src/components/__tests__/MileageRings.test.jsx
+++ b/frontend/src/components/__tests__/MileageRings.test.jsx
@@ -38,7 +38,7 @@ it('renders rings grouped by week', async () => {
   });
 
   render(<MileageRings goalKm={40} weeksToShow={1} />);
-  const ring = await screen.findByTitle(/Week of/);
+  const ring = await screen.findByLabelText(/Week of/);
   expect(ring).toBeInTheDocument();
   const base = import.meta.env.VITE_BACKEND_URL;
   expect(global.fetch).toHaveBeenCalledWith(`${base}/daily-totals`);
@@ -51,7 +51,7 @@ it('shows check icon when goal met', async () => {
   });
 
   const { container } = render(<MileageRings goalKm={50} weeksToShow={1} />);
-  await screen.findByTitle(/Week of/);
+  await screen.findByLabelText(/Week of/);
   const icon = container.querySelector('svg.lucide-check');
   expect(icon).toBeInTheDocument();
 });

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -18,7 +18,7 @@ export default function ProgressRing({
     <div
       className={"relative " + className}
       style={{ width: size, height: size }}
-      title={title}
+      aria-label={title}
     >
       <ResponsiveContainer width="100%" height="100%">
         <RadialBarChart


### PR DESCRIPTION
## Summary
- use aria labels instead of `title` attributes
- update Tooltip tests to match
- use `aria-label` for progress ring

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a886cb604832481474236e23379c5