### PR TITLE
Display pace numbers in WhatIfScenarios

### DIFF
--- a/frontend/src/components/WhatIfScenarios.jsx
+++ b/frontend/src/components/WhatIfScenarios.jsx
@@ -7,6 +7,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  LabelList,
 } from 'recharts';
 import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
 import { Slider } from './ui/Slider';
@@ -140,9 +141,29 @@ export default function WhatIfScenarios() {
               <XAxis dataKey="day" stroke="hsl(var(--muted-foreground))" />
               <YAxis unit="min/km" stroke="hsl(var(--muted-foreground))" />
               <Tooltip formatter={(v) => [`${v} min/km`, 'pace']} />
-              <Line type="monotone" dataKey="pace" stroke="hsl(var(--primary))" dot={false} />
+              <Line type="monotone" dataKey="pace" stroke="hsl(var(--primary))" dot={false}>
+                <LabelList dataKey="pace" position="top" formatter={(v) => v.toFixed(2)} />
+              </Line>
             </LineChart>
           </ResponsiveContainer>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm" aria-label="pace table">
+            <thead>
+              <tr className="text-muted-foreground">
+                <th className="px-2 py-1 text-left">Day</th>
+                <th className="px-2 py-1 text-right">Pace</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((d) => (
+                <tr key={d.day}>
+                  <td className="px-2 py-0.5">{d.day}</td>
+                  <td className="px-2 py-0.5 text-right">{d.pace} min/km</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
         <p className="text-sm text-muted-foreground">Predicted pace over the next 7 days (min/km)</p>
       </CardContent>

--- a/frontend/src/components/__tests__/WhatIfScenarios.test.jsx
+++ b/frontend/src/components/__tests__/WhatIfScenarios.test.jsx
@@ -67,3 +67,11 @@ test('runner avatar and trail are displayed', () => {
   expect(screen.getByTestId('runner')).toBeInTheDocument();
   expect(screen.getByTestId('trail')).toBeInTheDocument();
 });
+
+test('pace table shows predictions', () => {
+  render(<WhatIfScenarios />);
+  const table = screen.getByRole('table', { name: /pace table/i });
+  expect(table).toBeInTheDocument();
+  // check first row for day 1
+  expect(screen.getByText('1')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show pace labels on the line chart using `LabelList`
- add a small table listing each day's predicted pace
- test for the new pace table

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a8a0824088324aa6b91e195a18391