### PR TITLE
Add legend for weekly rings

### DIFF
--- a/frontend/src/components/WeeklyRingsDashboard.jsx
+++ b/frontend/src/components/WeeklyRingsDashboard.jsx
@@ -138,6 +138,16 @@ export default function WeeklyRingsDashboard({
         })}
       </svg>
       <figcaption className="mt-2 text-sm text-muted-foreground">{label}</figcaption>
+      <div className="mt-1 flex items-center gap-4 text-sm" data-testid="rings-legend">
+        <div className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: 'hsl(var(--chart-1))' }} />
+          <span>Run</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: 'hsl(var(--chart-2))' }} />
+          <span>Bike</span>
+        </div>
+      </div>
     </figure>
   );
 }

--- a/frontend/src/components/__tests__/WeeklyRingsDashboard.test.jsx
+++ b/frontend/src/components/__tests__/WeeklyRingsDashboard.test.jsx
@@ -52,3 +52,15 @@ test('paths include animation classes and initial dash values', async () => {
     expect(classes).toMatch(/animate/);
   });
 });
+
+test('renders legend labels', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(makeActivities(7, 5000)),
+  });
+
+  render(<WeeklyRingsDashboard weeksToShow={1} goalKm={40} />);
+  await screen.findByTestId('rings-legend');
+  expect(screen.getByText('Run')).toBeInTheDocument();
+  expect(screen.getByText('Bike')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add legend for run/bike colors in `WeeklyRingsDashboard`
- test legend rendering

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8bb26b9c832498104bd5e063916c