### PR TITLE
Add components list page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import DashboardPage from "@/components/DashboardPage";
 import AllChartsPage from "@/components/AllChartsPage";
 import AllMapsPage from "@/components/AllMapsPage";
+import AllComponentsPage from "@/components/AllComponentsPage";
 import ModeToggle from "@/components/ModeToggle";
 
 export default function App() {
@@ -24,6 +25,12 @@ export default function App() {
             >
               View All Maps
             </button>
+            <button
+              className="text-sm underline"
+              onClick={() => setPage("components")}
+            >
+              View Components
+            </button>
           </div>
         ) : (
           <button
@@ -40,8 +47,10 @@ export default function App() {
           <DashboardPage />
         ) : page === "charts" ? (
           <AllChartsPage />
-        ) : (
+        ) : page === "maps" ? (
           <AllMapsPage />
+        ) : (
+          <AllComponentsPage />
         )}
       </main>
     </div>

--- a/frontend/src/components/AllComponentsPage.jsx
+++ b/frontend/src/components/AllComponentsPage.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+const modules = import.meta.glob("./**/*.{jsx,tsx}", { eager: true });
+
+export default function AllComponentsPage() {
+  const components = React.useMemo(
+    () =>
+      Object.entries(modules)
+        .filter(
+          ([path, mod]) =>
+            !path.includes("__tests__") && typeof mod.default === "function"
+        )
+        .sort((a, b) => a[0].localeCompare(b[0])),
+    []
+  );
+
+  return (
+    <div className="p-6 space-y-6">
+      <h2 className="text-lg font-semibold">Component Files</h2>
+      <ul className="space-y-8">
+        {components.map(([path, mod]) => {
+          const Component = mod.default;
+          return (
+            <li key={path} className="space-y-2">
+              <div className="font-mono">{path.replace(/^\.\//, "")}</div>
+              <div className="border rounded p-4">
+                <Component />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `AllComponentsPage` component that lists every component file
- link to this page from the dashboard header
- show the new page in `App.jsx`
- display each component under its filename for easy reference

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aa61cb684832489dd32191b82f278