### PR TITLE
Fix maplibre import resolution

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,12 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  optimizeDeps: {
+    // maplibre-gl only provides a prebuilt bundle which can confuse
+    // Vite's dependency optimizer during import analysis.
+    // Excluding it prevents "Failed to resolve import" errors.
+    exclude: ['maplibre-gl'],
+  },
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary
- exclude `maplibre-gl` from Vite's dependency optimizer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aba7ebadc83249f8073d89321f7e3